### PR TITLE
Load coretemp module on boot

### DIFF
--- a/files/coretemp.modules
+++ b/files/coretemp.modules
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /sbin/modprobe coretemp >/dev/null 2>&1

--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -47,3 +47,29 @@
   tags:
     - collectd
     - pkgs
+
+- name: "Load coretemp module on boot"
+  copy: >
+    src=coretemp.modules
+    dest=/etc/sysconfig/modules/coretemp.modules
+    owner=root
+    group=root
+    mode=0700
+    state=present
+  when: monitor_coretemp and ansible_distribution_major_version|int == 6
+  tags:
+    - collectd
+    - files
+
+- name: "Load coretemp module on boot"
+  copy: >
+    content=coretemp
+    dest=/etc/modules-load.d/coretemp.conf
+    owner=root
+    group=root
+    mode=0600
+    state=present
+  when: monitor_coretemp and ansible_distribution_major_version|int == 7
+  tags:
+    - collectd
+    - files

--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -55,7 +55,6 @@
     owner=root
     group=root
     mode=0700
-    state=present
   when: monitor_coretemp and ansible_distribution_major_version|int == 6
   tags:
     - collectd
@@ -68,7 +67,6 @@
     owner=root
     group=root
     mode=0600
-    state=present
   when: monitor_coretemp and ansible_distribution_major_version|int == 7
   tags:
     - collectd

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -17,3 +17,12 @@
     - install
     - collectd
     - pkgs
+
+- name: "Load coretemp module on boot"
+  lineinfile: >
+    dest=/etc/modules
+    line=coretemp
+  when: monitor_coretemp
+  tags:
+    - collectd
+    - files


### PR DESCRIPTION
- CentOS 6: https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/sec-Persistent_Module_Loading.html
- CentOS 7: https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sec-Persistent_Module_Loading.html
