### PR TITLE
Amazon Linux support

### DIFF
--- a/tasks/amazon.yml
+++ b/tasks/amazon.yml
@@ -1,0 +1,29 @@
+- include_vars: "Amazon.yml"
+
+- name: "Set collectd's config file destination"
+  set_fact: >
+    collectd_config_dest=/etc/collectd.conf
+  tags:
+    - collectd
+
+- name: "Clean old packages"
+  yum: >
+    name={{ item }}
+    state=absent
+  with_items:
+    - collectd-python
+    - collectd-hddtemp
+    - libcollectdclient
+  tags:
+    - collectd
+    - pkgs
+
+- name: "Install required packages"
+  yum : >
+    name={{ item }}
+    state=latest
+  with_items: packages
+  tags:
+    - collectd
+    - pkgs
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,9 @@
 - include: debian.yml
   when: ansible_distribution == "Debian"
 
+- include: amazon.yml
+  when: ansible_distribution == "Amazon"
+
 #####################
 # Common
 - name: "Ensure the collectd exec module directory exists"

--- a/vars/Amazon.yml
+++ b/vars/Amazon.yml
@@ -1,0 +1,24 @@
+packages:
+  - collectd
+  - collectd-amqp
+  - collectd-apache
+  - collectd-bind
+  - collectd-curl
+  - collectd-curl_xml
+  - collectd-dbi
+  - collectd-dns
+  - collectd-email
+  - collectd-generic-jmx
+  - collectd-ipmi
+  - collectd-iptables
+  - collectd-ipvs
+  - collectd-java
+  - collectd-lvm
+  - collectd-mysql
+  - collectd-netlink
+  - collectd-nginx
+  - collectd-notify_email
+  - collectd-postgresql
+  - collectd-rrdcached
+  - collectd-rrdtool
+  - collectd-snmp


### PR DESCRIPTION
We use the collectd provided by Amazon, as such a couple modules are missing:
- curl_json
- notify_desktop
- ping
- sensors
- virt
- write_riemann
