### PR TITLE
have all machines send to Librato when a collectd_forwarder is not defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ By default, we will save all metrics to RRD files under `/var/lib/collectd/rrd/$
 Normally, we put all aggregation on a single machine.
 However, it is possible to decouple them, and provision separate machines for any aggregators we might have.
 This example demonstrate how to create a dedicated collectd aggregator.
+`collectd_forwarder` defines the host that is the dedicated collectd aggregator. Default is an empty string, '',
+which configures the network plugin to not send to a collectd aggregator.
+
 
 ```ini
 [collectd:children]
@@ -69,7 +72,7 @@ The following may also be added to your inventory.
 * `collectd_df_ValuesAbsolute`: [see wiki](https://collectd.org/wiki/index.php/Plugin:DF#Parameters) (default: true)
 * `collectd_df_ValuesPercentage`: [see wiki](https://collectd.org/wiki/index.php/Plugin:DF#Parameters) (default: false)
 * `monitor_coretemp`: set to true if you want to monitor coretemp (only useful on real hardware)
-* `private_ip`: set to the IP address of the `collectd_forwarder` if `collectd_fowarder` has multiple IPs. Example:
+* `private_ip`: set to the IP address of the `collectd_forwarder` if `collectd_forwarder` has multiple IPs. Example:
 ```
 collectd1.somedc.prod         ansible_ssh_host=10.0.1.111   private_ip=172.16.1.111
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 monitor_coretemp: false
 collectd_forward_to_logstash: false
 
+collectd_forwarder: ''
+
 use_librato: false
 use_graphite: false
 

--- a/templates/plugin-configs/librato.conf.j2
+++ b/templates/plugin-configs/librato.conf.j2
@@ -1,5 +1,5 @@
 {% if use_librato|bool %}
-{% if (collectd_forwarder is defined and collectd_forwarder == inventory_hostname) or (collectd_forwarder is not defined) %}
+{% if (collectd_forwarder == inventory_hostname) or (collectd_forwarder == '') %}
 LoadPlugin write_http
 <Plugin write_http>
 {% if installed_version|version_compare("5.4", "<=") %}

--- a/templates/plugin-configs/librato.conf.j2
+++ b/templates/plugin-configs/librato.conf.j2
@@ -1,4 +1,5 @@
-{% if use_librato|bool and collectd_forwarder is defined and collectd_forwarder == inventory_hostname %}
+{% if use_librato|bool %}
+{% if (collectd_forwarder is defined and collectd_forwarder == inventory_hostname) or (collectd_forwarder is not defined) %}
 LoadPlugin write_http
 <Plugin write_http>
 {% if installed_version|version_compare("5.4", "<=") %}
@@ -17,4 +18,5 @@ LoadPlugin write_http
   </Node>
 {% endif %}
 </Plugin>
+{% endif %}
 {% endif %}

--- a/templates/plugin-configs/network.conf.j2
+++ b/templates/plugin-configs/network.conf.j2
@@ -1,11 +1,12 @@
+{% if collectd_forwarder != '' %}
 LoadPlugin network
 <Plugin network>
-    {% if collectd_forwarder is defined and collectd_forward_to_logstash|bool %}
+    {% if collectd_forward_to_logstash|bool %}
         <Server "{{ hostvars[collectd_forwarder]['private_ip']|default(hostvars[collectd_forwarder]['ansible_ssh_host']) }}" "25827">
                 Interface "{{ private_interface }}"
         </Server>
         TimeToLive 128
-    {% elif collectd_forwarder is defined and collectd_forwarder != inventory_hostname %}
+    {% elif collectd_forwarder != inventory_hostname %}
         <Server "{{ hostvars[collectd_forwarder]['private_ip']|default(hostvars[collectd_forwarder]['ansible_ssh_host']) }}" "25826">
                 Interface "{{ private_interface }}"
         </Server>
@@ -19,3 +20,4 @@ LoadPlugin network
         # statistics about the network plugin itself
         ReportStats false
 </Plugin>
+{% endif %}

--- a/templates/plugin-configs/write_graphite.conf.j2
+++ b/templates/plugin-configs/write_graphite.conf.j2
@@ -1,4 +1,4 @@
-{% if collectd_forwarder is defined and collectd_forwarder == inventory_hostname  %}
+{% if collectd_forwarder == inventory_hostname  %}
 {% if use_graphite|bool %}
 LoadPlugin python
 <LoadPlugin write_graphite>


### PR DESCRIPTION
Sometimes a collectd server does not exist, so all machines would need to their metrics sent to Librato.

`collectd_forwarder` defaults to an empty string, `''`.

When using [Librato](https://www.librato.com), this PR allows all machines to be configured to send to Librato when `collectd_forwarder` is set to a host.