### PR TITLE
Fix `with_items` for Ansible 2.3 + Update deprecated choice

### DIFF
--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -32,7 +32,7 @@
     name={{ item }}
     enablerepo=epel,gf-plus
     state=latest
-  with_items: packages
+  with_items: "{{ packages }}"
   when: ansible_distribution_major_version|int == 6
   tags:
     - collectd
@@ -43,7 +43,7 @@
     name={{ item }}
     enablerepo=epel
     state=latest
-  with_items: packages
+  with_items: "{{ packages }}"
   when: ansible_distribution_major_version|int > 6
   tags:
     - collectd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,7 +75,7 @@
 - name: "Make sure collectd is running"
   service: >
     name=collectd
-    state=running
+    state=started
     enabled=yes
     runlevel=5
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
     src=plugin-configs/{{ item }}.conf.j2
     dest={{ collectd_d_config_dir }}/{{ item }}.conf
     mode=0644
-  with_items: collectd_plugins
+  with_items: "{{ collectd_plugins }}"
   notify:
     - Restart collectd
   tags:


### PR DESCRIPTION
2 fixes:

1) Ansible 2.3.1 requires the `packages` variable to be wrapped in double quotes and curly braces `"{{ }}"`. Fixes this error:
```
TASK [AerisCloud.collectd : Install required packages] ************************************************************************************************************************************************************************************************************************
failed: [172.16.1.100] (item=[u'packages']) => {"cmd": "yum -y -d 2 --enablerepo=epel install packages", "failed": true, "item": ["packages"], "msg": "Error: Nothing to do", "rc": 1, "stderr": "Error: Nothing to do\n", "stderr_lines": ["Error: Nothing to do"], "stdout": "Loaded plugins: fastestmirror\nLoading mirror speeds from cached hostfile\n * base: ftp.tsukuba.wide.ad.jp\n * epel: s3-mirror-ap-northeast-1.fedoraproject.org\n * extras: ftp.tsukuba.wide.ad.jp\n * updates: ftp.tsukuba.wide.ad.jp\nNo package packages available.\n", "stdout_lines": ["Loaded plugins: fastestmirror", "Loading mirror speeds from cached hostfile", " * base: ftp.tsukuba.wide.ad.jp", " * epel: s3-mirror-ap-northeast-1.fedoraproject.org", " * extras: ftp.tsukuba.wide.ad.jp", " * updates: ftp.tsukuba.wide.ad.jp", "No package packages available."]}
```


2) Switch from `state=running` to `state=started`:
```
TASK [AerisCloud.collectd : Make sure collectd is running] ***************************************************************************
[DEPRECATION WARNING]: state=running is deprecated. Please use state=started.
This feature will be removed in version 2.7.
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
 [WARNING]: Ignoring "runlevel" as it is not used in "systemd"
```